### PR TITLE
Fixed AlbumGroupCards not being resizable and not keeping aspect ratio

### DIFF
--- a/example/lib/components/album_group_card_demo_page.dart
+++ b/example/lib/components/album_group_card_demo_page.dart
@@ -1,0 +1,73 @@
+import 'package:dots_design_system/dots_design_system.dart';
+import 'package:flutter/material.dart';
+
+class AlbumGroupCardDemoPage extends StatelessWidget {
+  final ImageProvider imageProvider;
+  final String title;
+  final AlbumGroupCardVariant variant;
+  final DotsIconData? tagIconData;
+
+  const AlbumGroupCardDemoPage({
+    super.key,
+    required this.imageProvider,
+    required this.title,
+    required this.variant,
+    this.tagIconData,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return variant == AlbumGroupCardVariant.small
+        ? Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Expanded(
+                child: AlbumGroupCard(
+                  imageProvider: imageProvider,
+                  title: title,
+                  variant: variant,
+                  tagIconData: tagIconData,
+                  onTap: () {},
+                  onError: (exception, stackTrace) {},
+                ),
+              ),
+              SizedBox(
+                width: 20.0,
+              ),
+              Expanded(
+                child: AlbumGroupCard(
+                  imageProvider: imageProvider,
+                  title: title,
+                  variant: variant,
+                  tagIconData: tagIconData,
+                  onTap: () {},
+                  onError: (exception, stackTrace) {},
+                ),
+              ),
+            ],
+          )
+        : Column(
+            children: [
+              AlbumGroupCard(
+                imageProvider: imageProvider,
+                title: title,
+                variant: variant,
+                tagIconData: tagIconData,
+                onTap: () {},
+                onError: (exception, stackTrace) {},
+              ),
+              SizedBox(
+                height: 20.0,
+              ),
+              AlbumGroupCard(
+                imageProvider: imageProvider,
+                title: title,
+                variant: variant,
+                tagIconData: tagIconData,
+                onTap: () {},
+                onError: (exception, stackTrace) {},
+              ),
+            ],
+          );
+  }
+}

--- a/example/lib/stories/stories_by_folder/group_cards_stories.dart
+++ b/example/lib/stories/stories_by_folder/group_cards_stories.dart
@@ -2,13 +2,15 @@ import 'package:dots_design_system/dots_design_system.dart';
 import 'package:flutter/widgets.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
+import '../../components/album_group_card_demo_page.dart';
+
 List<Story> get groupCards => [
       Story(
         name: 'Cards/Album Group Cards',
         description: 'Demo page for album group cards',
         builder: (context) => Padding(
           padding: const EdgeInsets.all(16.0),
-          child: AlbumGroupCard(
+          child: AlbumGroupCardDemoPage(
             imageProvider: NetworkImage(
               context.knobs.text(
                 label: 'Container background image',
@@ -29,8 +31,6 @@ List<Story> get groupCards => [
               options:
                   DotsIconData.values.map((item) => Option(label: item.name, value: item)).toList(),
             ),
-            onTap: () {},
-            onError: (exception, stackTrace) {},
           ),
         ),
       ),

--- a/lib/src/components/cards/group_cards/album_group_card.dart
+++ b/lib/src/components/cards/group_cards/album_group_card.dart
@@ -42,12 +42,15 @@ class AlbumGroupCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = context.dotsTheme;
 
-    return Center(
-      child: GestureDetector(
-        onTap: onTap,
+    return GestureDetector(
+      onTap: onTap,
+      child: AspectRatio(
+        aspectRatio: 1.0,
         child: Container(
           clipBehavior: Clip.antiAlias,
           constraints: BoxConstraints(
+            minWidth: variant.isSmall ? 135 : 288,
+            minHeight: variant.isSmall ? 135 : 288,
             maxHeight: variant.isSmall ? 160 : 340,
             maxWidth: variant.isSmall ? 160 : 340,
           ),
@@ -86,18 +89,15 @@ class AlbumGroupCard extends StatelessWidget {
                   children: [
                     Align(
                       alignment: Alignment.bottomCenter,
-                      child: SizedBox(
-                        width: double.infinity,
-                        child: Text(
-                          title,
-                          textAlign: TextAlign.center,
-                          style: (variant.isSmall
-                                  ? theme.typo.main.labelDefaultMedium
-                                  : theme.typo.main.bodyLargeMedium)
-                              .copyWith(color: theme.colors.labelAlwaysWhite),
-                          overflow: TextOverflow.ellipsis,
-                          maxLines: 1,
-                        ),
+                      child: Text(
+                        title,
+                        textAlign: TextAlign.center,
+                        style: (variant.isSmall
+                                ? theme.typo.main.labelDefaultMedium
+                                : theme.typo.main.bodyLargeMedium)
+                            .copyWith(color: theme.colors.labelAlwaysWhite),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
                       ),
                     ),
                     if (tagIconData != null)


### PR DESCRIPTION
# Changes
- Added new demo page to prove AlbumGroupCards resize accordingly when put under a smaller screen
- Fixed issue when album group cards where put into smaller screens