### PR TITLE
Set the same size for events and albums in home

### DIFF
--- a/lib/src/components/cards/group_cards/event_group_card.dart
+++ b/lib/src/components/cards/group_cards/event_group_card.dart
@@ -61,12 +61,15 @@ class EventGroupCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = context.dotsTheme;
 
-    return Center(
-      child: GestureDetector(
-        onTap: onTap,
+    return GestureDetector(
+      onTap: onTap,
+      child: AspectRatio(
+        aspectRatio: 1.0,
         child: Container(
           clipBehavior: Clip.antiAlias,
           constraints: BoxConstraints(
+            minWidth: variant.isSmall ? 135 : 288,
+            minHeight: variant.isSmall ? 135 : 288,
             maxHeight: variant.isSmall ? 160 : 340,
             maxWidth: variant.isSmall ? 160 : 340,
           ),


### PR DESCRIPTION
<img width="300" height="2388" alt="Screenshot_20251003-163029_Dots" src="https://github.com/user-attachments/assets/658f612e-1eb5-43e2-945c-bad6f553e1d6" />
<img width="300" height="2388" alt="Screenshot_20251003-163059_Dots" src="https://github.com/user-attachments/assets/88070661-efd3-4b5e-aec5-bc80de33077e" />
