### PR TITLE
Fix gradient blur bleeding past rounded card corners (#8476)

### DIFF
--- a/lib/src/components/cards/group_cards/album_group_card.dart
+++ b/lib/src/components/cards/group_cards/album_group_card.dart
@@ -75,29 +75,29 @@ class AlbumGroupCard extends StatelessWidget {
             styleType: styleType,
             child: Stack(
               children: [
-                SoftEdgeBlur(
-                  edges: [
-                    EdgeBlur(
-                      type: EdgeType.bottomEdge,
-                      size: bottomBlurHeight,
-                      sigma: blurSigma ?? 12,
-                      controlPoints: [
-                        ControlPoint(
-                          position: 0.5,
-                          type: ControlPointType.visible,
-                        ),
-                        ControlPoint(
-                          position: 1,
-                          type: ControlPointType.transparent,
-                        ),
-                      ],
-                    ),
-                  ],
-                  child: ClipSmoothRect(
-                    radius: SmoothBorderRadius(
-                      cornerRadius: styleType.radius,
-                      cornerSmoothing: styleType.cornerSmoothing,
-                    ),
+                ClipSmoothRect(
+                  radius: SmoothBorderRadius(
+                    cornerRadius: styleType.radius,
+                    cornerSmoothing: styleType.cornerSmoothing,
+                  ),
+                  child: SoftEdgeBlur(
+                    edges: [
+                      EdgeBlur(
+                        type: EdgeType.bottomEdge,
+                        size: bottomBlurHeight,
+                        sigma: blurSigma ?? 12,
+                        controlPoints: [
+                          ControlPoint(
+                            position: 0.5,
+                            type: ControlPointType.visible,
+                          ),
+                          ControlPoint(
+                            position: 1,
+                            type: ControlPointType.transparent,
+                          ),
+                        ],
+                      ),
+                    ],
                     child: Image(
                       image: imageProvider,
                       fit: BoxFit.cover,

--- a/lib/src/components/cards/group_cards/event_group_card.dart
+++ b/lib/src/components/cards/group_cards/event_group_card.dart
@@ -90,29 +90,29 @@ class EventGroupCard extends StatelessWidget {
             styleType: styleType,
             child: Stack(
               children: [
-                SoftEdgeBlur(
-                  edges: [
-                    EdgeBlur(
-                      type: EdgeType.bottomEdge,
-                      size: bottomBlurHeight,
-                      sigma: 12,
-                      controlPoints: [
-                        ControlPoint(
-                          position: 0.5,
-                          type: ControlPointType.visible,
-                        ),
-                        ControlPoint(
-                          position: 1,
-                          type: ControlPointType.transparent,
-                        ),
-                      ],
-                    ),
-                  ],
-                  child: ClipSmoothRect(
-                    radius: SmoothBorderRadius(
-                      cornerRadius: styleType.radius,
-                      cornerSmoothing: styleType.cornerSmoothing,
-                    ),
+                ClipSmoothRect(
+                  radius: SmoothBorderRadius(
+                    cornerRadius: styleType.radius,
+                    cornerSmoothing: styleType.cornerSmoothing,
+                  ),
+                  child: SoftEdgeBlur(
+                    edges: [
+                      EdgeBlur(
+                        type: EdgeType.bottomEdge,
+                        size: bottomBlurHeight,
+                        sigma: 12,
+                        controlPoints: [
+                          ControlPoint(
+                            position: 0.5,
+                            type: ControlPointType.visible,
+                          ),
+                          ControlPoint(
+                            position: 1,
+                            type: ControlPointType.transparent,
+                          ),
+                        ],
+                      ),
+                    ],
                     child: Image(
                       image: imageProvider,
                       fit: BoxFit.cover,


### PR DESCRIPTION
## Issue
#8476 — the bottom gradient blur on group cards fades along the entire rectangular border, bleeding into the square corners and side edges.

## Fix
Inverted the widget nesting in both `album_group_card.dart` and `event_group_card.dart` so `ClipSmoothRect` wraps the whole `SoftEdgeBlur` instead of just the `Image`.

Previously `SoftEdgeBlur` rendered its blur on its own rectangular bounds *outside* the rounded clip, so only the image was rounded — the blurred band bled into the corners and sides. Clipping the entire blur output to the smooth rounded shape keeps the fade vertical and leaves the rounded/lateral edges clipped by the card mask.

All existing `EdgeBlur` parameters (size, sigma, controlPoints) and `Image` props (including `errorBuilder`) are preserved exactly — the only change is the nesting order. Other `Stack` siblings (bottom gradient, text padding, top gradient) are untouched.

## Verification
- `flutter analyze` on the package: **No issues found**

> Note: tagging is manual in this repo (no CI workflow). After merge, a `v1.67.2` tag should be created on the resulting `develop` merge commit so the app can point its git ref at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)