### PR TITLE
fix(toast): wire onTap to the progress toast action button

### DIFF
--- a/lib/src/components/toast/dots_toast.dart
+++ b/lib/src/components/toast/dots_toast.dart
@@ -138,6 +138,7 @@ class DotsToast extends StatelessWidget {
                 variant: DotsMainButtonVariant.ghost,
                 size: DotsMainButtonSize.medium,
                 adaptPaddingForText: true,
+                onTap: onTap,
               ),
           ],
         ),


### PR DESCRIPTION
## What

Forward the toast's `onTap` to the action button rendered for progress info toasts
(`DotsToast` → the `btnTitle` `DotsMainButton`).

## Why

For an info/progress toast with a `btnTitle` (e.g. the web upload **"see progress"** toast), the
action button was built without an `onTap`:

```dart
DotsMainButton(
  content: btnTitle!,
  variant: DotsMainButtonVariant.ghost,
  size: DotsMainButtonSize.medium,
  adaptPaddingForText: true,
)
```

A `DotsMainButton` with `enabled: true` (the default) and a `null` `onTap` still installs a tap
handler (`_handleTap`) that **consumes the tap and does nothing**. Because the button sits on top of
the toast's outer `GestureDetector`, tapping the button was swallowed — so the action button did
nothing when pressed.

Surfaced in `onelife_app` while fixing the web group-landing "see memories" flow
(onelife-social/onelife_app#10977): the **"see progress"** toast button on the memories list did
not navigate back to the upload progress page.

## Change

```dart
DotsMainButton(
  content: btnTitle!,
  variant: DotsMainButtonVariant.ghost,
  size: DotsMainButtonSize.medium,
  adaptPaddingForText: true,
  onTap: onTap, // forward the toast callback so the action button is tappable
)
```

Additive and backwards compatible: when no `onTap` is provided the button keeps its previous
(inert) behaviour; existing toasts without a `btnTitle` are unaffected.

## Testing

- `dart analyze` clean on the changed file.
- Verified visually unchanged (no golden impact — only wires an existing callback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
