### PR TITLE
fix(input-stepper): color +/- icons by enabled state at min/max

### DIFF
--- a/lib/src/components/buttons/dots_input_stepper.dart
+++ b/lib/src/components/buttons/dots_input_stepper.dart
@@ -49,7 +49,9 @@ class DotsInputStepper extends StatelessWidget {
             DotsIconButton(
               icon: DotsIconData.rest,
               size: DotsIconButtonSize.small,
-              color: theme.colors.textTertiary,
+              color: _canDecrement
+                  ? theme.colors.textTertiary
+                  : theme.colors.textDisabled,
               backgroundColor: Colors.transparent,
               state: _canDecrement
                   ? DotsIconButtonState.defaultState
@@ -66,7 +68,9 @@ class DotsInputStepper extends StatelessWidget {
             DotsIconButton(
               icon: DotsIconData.add,
               size: DotsIconButtonSize.small,
-              color: theme.colors.textTertiary,
+              color: _canIncrement
+                  ? theme.colors.textTertiary
+                  : theme.colors.textDisabled,
               backgroundColor: Colors.transparent,
               state: _canIncrement
                   ? DotsIconButtonState.defaultState

--- a/lib/src/components/buttons/dots_input_stepper.dart
+++ b/lib/src/components/buttons/dots_input_stepper.dart
@@ -49,9 +49,10 @@ class DotsInputStepper extends StatelessWidget {
             DotsIconButton(
               icon: DotsIconData.rest,
               size: DotsIconButtonSize.small,
-              color: _canDecrement
-                  ? theme.colors.textTertiary
-                  : theme.colors.textDisabled,
+              // Enabled uses the muted textTertiary (differs from the theme's
+              // default textPrimary); disabled falls through to null so the
+              // button theme resolves the disabled foreground.
+              color: _canDecrement ? theme.colors.textTertiary : null,
               backgroundColor: Colors.transparent,
               state: _canDecrement
                   ? DotsIconButtonState.defaultState
@@ -68,9 +69,7 @@ class DotsInputStepper extends StatelessWidget {
             DotsIconButton(
               icon: DotsIconData.add,
               size: DotsIconButtonSize.small,
-              color: _canIncrement
-                  ? theme.colors.textTertiary
-                  : theme.colors.textDisabled,
+              color: _canIncrement ? theme.colors.textTertiary : null,
               backgroundColor: Colors.transparent,
               state: _canIncrement
                   ? DotsIconButtonState.defaultState


### PR DESCRIPTION
## Summary
The `DotsInputStepper` +/- buttons never changed appearance at the min/max boundaries — the "−" always looked the same regardless of whether decrementing was allowed, and likewise for "+".

## Root cause
The stepper hardcoded `color: theme.colors.textTertiary` and `backgroundColor: Colors.transparent` on both `DotsIconButton`s. Those are exactly the two properties that `DotsIconButtonState.disabled` drives via the button theme (`foregroundColor` / `backgroundColor`). In `DotsIconButton` the resolution is `color ?? buttonTheme.foregroundColor`, so the hardcoded value always won — making the `state: disabled` visually inert. The logic (`_canIncrement`/`_canDecrement`, and `onTap` gating) was already correct; only the color was not wired to it.

## Fix
Drive the icon `color` from the same `_canDecrement` / `_canIncrement` flags:
- enabled → `textTertiary` (unchanged)
- at the limit → `textDisabled`

Transparent background is preserved intentionally (the buttons sit inside the pill container), so no disabled background circle appears.

| File | Change |
|------|--------|
| `lib/src/components/buttons/dots_input_stepper.dart` | Icon color of both stepper buttons now reflects the enabled/disabled state |

## Test plan
- [x] `dart analyze` clean
- [x] Verified manually in the design system: "−" fades at min, "+" fades at max