### PR TITLE
fix(dotbook-cover): use tabular figures for create progress

### DIFF
--- a/lib/src/components/dot_book/dotbook_cover/dotbook_cover_overlay_image.dart
+++ b/lib/src/components/dot_book/dotbook_cover/dotbook_cover_overlay_image.dart
@@ -538,6 +538,7 @@ class _DotBookCoverOverlayImage extends StatelessWidget {
                     createprogress,
                     style: theme.typo.main.titleH3.copyWith(
                       color: theme.colors.labelAlwaysWhite,
+                      fontFeatures: const [FontFeature.tabularFigures()],
                     ),
                   ),
                 ),


### PR DESCRIPTION
Prevents horizontal jitter of the centered progress number when its value changes (10%, 20%, ... 100%) by forcing equal-width digits.