### PR TITLE
feat(empty-state): support rich description in DotsEmptyStateCard

### DIFF
--- a/lib/src/components/empty_state/empty_state_card.dart
+++ b/lib/src/components/empty_state/empty_state_card.dart
@@ -89,7 +89,7 @@ class DotsEmptyStateCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 8),
-          if (spans != null)
+          if (spans != null && spans.isNotEmpty)
             Text.rich(
               TextSpan(children: spans),
               style: descriptionStyle,

--- a/lib/src/components/empty_state/empty_state_card.dart
+++ b/lib/src/components/empty_state/empty_state_card.dart
@@ -34,6 +34,10 @@ class DotsEmptyStateCard extends StatelessWidget {
   /// Width of the image.
   final double? imageWidth;
 
+  /// Rich description rendered instead of [description] when set; [description]
+  /// stays as the accessibility label.
+  final List<InlineSpan>? descriptionSpans;
+
   const DotsEmptyStateCard({
     super.key,
     required this.variant,
@@ -46,11 +50,16 @@ class DotsEmptyStateCard extends StatelessWidget {
     this.button,
     this.extraSpaceAfterImage = 0,
     this.imageWidth,
+    this.descriptionSpans,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = context.dotsTheme;
+    final TextStyle descriptionStyle = theme.typo.main.bodyDefaultRegular.copyWith(
+      color: descriptionColor ?? theme.colors.textQuarternary,
+    );
+    final List<InlineSpan>? spans = descriptionSpans;
 
     return Container(
       width: context.screenWidth * context.getByRatio(0.8205, 0.9),
@@ -80,13 +89,19 @@ class DotsEmptyStateCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 8),
-          Text(
-            description,
-            style: theme.typo.main.bodyDefaultRegular.copyWith(
-              color: descriptionColor ?? theme.colors.textQuarternary,
+          if (spans != null)
+            Text.rich(
+              TextSpan(children: spans),
+              style: descriptionStyle,
+              textAlign: TextAlign.center,
+              semanticsLabel: description,
+            )
+          else
+            Text(
+              description,
+              style: descriptionStyle,
+              textAlign: TextAlign.center,
             ),
-            textAlign: TextAlign.center,
-          ),
           if (button != null) ...[
             SizedBox(height: context.getByRatio(16, 10)),
             button!,


### PR DESCRIPTION
## What

Adds an optional `descriptionSpans` (`List<InlineSpan>?`) to `DotsEmptyStateCard`. When provided, the description is rendered as `Text.rich` using the same base style (`bodyDefaultRegular` + description color), and `description` stays as the accessibility label. When omitted, behavior is unchanged (plain `Text`).

## Why

The memories gallery empty state (onelife_app issue #11263) needs partially-bold text: the capture dates in the event-stage empty state must be bold while the times keep the regular weight. `DotsEmptyStateCard` only rendered a plain `String`, so this was not possible without a rich-text hook.

## Notes

- Purely additive — the new field defaults to `null`, no existing caller changes.
- Consumed by `onelife_app` in the memories gallery empty state (app PR to follow); a new tag will be needed there once this merges.
