### PR TITLE
feat(icon-item): subtitle + qr slot for DotsIconItem

### DIFF
--- a/lib/src/components/icons/icon_item/dots_icon_item.dart
+++ b/lib/src/components/icons/icon_item/dots_icon_item.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 import '../../../core/extensions/extensions_lib.dart';
 import '../icons_lib.dart';
 
-/// A widget that represents an icon item, which consists of an icon slot and a text label.
+/// A widget that represents an icon item, which consists of an icon slot and a
+/// text label with an optional supporting subtitle.
 class DotsIconItem extends StatelessWidget {
   /// Type of the icon item, which determines the image to be displayed in the slot.
   final DotsIconItemSlotType type;
@@ -11,10 +12,19 @@ class DotsIconItem extends StatelessWidget {
   /// Text label to be displayed next to the icon slot.
   final String label;
 
+  /// Optional secondary line shown under [label] (e.g. a selection summary).
+  final String? subtitle;
+
   /// Callback function to be called when the icon item is tapped.
   final VoidCallback? onTap;
 
-  const DotsIconItem({required this.type, required this.label, this.onTap, super.key});
+  const DotsIconItem({
+    required this.type,
+    required this.label,
+    this.subtitle,
+    this.onTap,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -31,13 +41,8 @@ class DotsIconItem extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
                   DotsIconItemSlot(type: type),
-                  SizedBox(width: 12),
-                  Text(
-                    label,
-                    style: context.dotsTheme.typo.main.bodyLargeMedium.copyWith(
-                      color: context.dotsTheme.colors.textPrimary,
-                    ),
-                  ),
+                  const SizedBox(width: 12),
+                  Expanded(child: _labelColumn(context)),
                 ],
               ),
             ),
@@ -50,6 +55,35 @@ class DotsIconItem extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+
+  Widget _labelColumn(BuildContext context) {
+    final theme = context.dotsTheme;
+    final Text labelText = Text(
+      label,
+      style: theme.typo.main.bodyLargeMedium.copyWith(
+        color: theme.colors.textPrimary,
+      ),
+    );
+
+    if (subtitle == null) {
+      return labelText;
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        labelText,
+        const SizedBox(height: 2),
+        Text(
+          subtitle!,
+          style: theme.typo.main.labelDefaultRegular.copyWith(
+            color: theme.colors.textSecondary,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/components/icons/icon_item/dots_icon_item_slot.dart
+++ b/lib/src/components/icons/icon_item/dots_icon_item_slot.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 import '../../../core/core_lib.dart';
+import '../dots_icon.dart';
+import '../dots_icon_data_enum.dart';
 
 class DotsIconItemSlot extends StatelessWidget {
   /// Type of the icon slot, which determines the image to be displayed.
@@ -21,10 +23,47 @@ class DotsIconItemSlot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (type == DotsIconItemSlotType.qr) {
+      return _QrSlot(width: width, height: height);
+    }
+
     return Image.asset(
       '${ImagesPaths.imagesIcons}/icon_${type.name}.webp',
       width: width,
       height: height,
+    );
+  }
+}
+
+/// The `qr` slot has no raster illustration in the asset set; it is composed
+/// from the QR glyph over the brand blue gradient so it stays crisp at any size
+/// and matches the rest of the icon family.
+class _QrSlot extends StatelessWidget {
+  final double width;
+  final double height;
+
+  const _QrSlot({required this.width, required this.height});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        gradient: const LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [Color(0xFF82C8E5), Color(0xFF4FAEF8)],
+        ),
+      ),
+      child: Center(
+        child: DotsIcon(
+          iconData: DotsIconData.qr,
+          color: Colors.white,
+          size: width * 0.55,
+        ),
+      ),
     );
   }
 }
@@ -34,4 +73,5 @@ enum DotsIconItemSlotType {
   dedicatory,
   images,
   milestone,
+  qr,
 }


### PR DESCRIPTION
## What
Extends `DotsIconItem` for the Dotbook "Códigos QR" draft entry (onelife_app #11174):

- **`DotsIconItem.subtitle`** — optional secondary line rendered under the label (Label/Default/Regular, `textSecondary`). Backward compatible; existing call sites are unaffected.
- **`DotsIconItemSlotType.qr`** — new slot type. Rendered as a composed blue-gradient rounded-square (`#82C8E5 → #4FAEF8`, matching the Figma spec) with a white `DotsIconData.qr` glyph. No new raster asset is shipped.

## Why
The app's Dotbook draft manager needs a "Códigos QR" row that shows a `"{n} hitos · {m} vídeos"` subtitle with a QR icon — capabilities `DotsIconItem` did not have.

## Notes
- No existing `DotsIconItem` tests/goldens in this repo; `flutter analyze` on the component is clean.
- Consumed by onelife_app branch `feature-11174-gestionar-codigos-qr-en-dotbook-de-recuerdos` (currently via a local `dependency_overrides` path until this is merged + tagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)