### PR TITLE
feat(icon-item): soft-rectangle DotsIconItem slot icons

### DIFF
--- a/lib/src/components/icons/icon_item/dots_icon_item_slot.dart
+++ b/lib/src/components/icons/icon_item/dots_icon_item_slot.dart
@@ -23,12 +23,15 @@ class DotsIconItemSlot extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final _SlotSpec spec = _specFor(type);
+    // Derive the corner radius and glyph size from the smaller side so a
+    // non-square slot never overflows its shorter dimension.
+    final double side = width < height ? width : height;
 
     return Container(
       width: width,
       height: height,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(width * 0.24),
+        borderRadius: BorderRadius.circular(side * 0.24),
         gradient: LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
@@ -39,7 +42,7 @@ class DotsIconItemSlot extends StatelessWidget {
         child: DotsIcon(
           iconData: spec.glyph,
           color: Colors.white,
-          size: width * 0.55,
+          size: side * 0.55,
         ),
       ),
     );

--- a/lib/src/components/icons/icon_item/dots_icon_item_slot.dart
+++ b/lib/src/components/icons/icon_item/dots_icon_item_slot.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
 
-import '../../../core/core_lib.dart';
 import '../dots_icon.dart';
 import '../dots_icon_data_enum.dart';
 
 class DotsIconItemSlot extends StatelessWidget {
-  /// Type of the icon slot, which determines the image to be displayed.
+  /// Type of the icon slot, which determines the glyph and gradient shown.
   final DotsIconItemSlotType type;
 
   /// Width of the icon slot. Default is 44.
@@ -23,49 +22,52 @@ class DotsIconItemSlot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (type == DotsIconItemSlotType.qr) {
-      return _QrSlot(width: width, height: height);
-    }
+    final _SlotSpec spec = _specFor(type);
 
-    return Image.asset(
-      '${ImagesPaths.imagesIcons}/icon_${type.name}.webp',
-      width: width,
-      height: height,
-    );
-  }
-}
-
-/// The `qr` slot has no raster illustration in the asset set; it is composed
-/// from the QR glyph over the brand blue gradient so it stays crisp at any size
-/// and matches the rest of the icon family.
-class _QrSlot extends StatelessWidget {
-  final double width;
-  final double height;
-
-  const _QrSlot({required this.width, required this.height});
-
-  @override
-  Widget build(BuildContext context) {
     return Container(
       width: width,
       height: height,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(8),
-        gradient: const LinearGradient(
+        borderRadius: BorderRadius.circular(width * 0.24),
+        gradient: LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
-          colors: [Color(0xFF82C8E5), Color(0xFF4FAEF8)],
+          colors: spec.colors,
         ),
       ),
       child: Center(
         child: DotsIcon(
-          iconData: DotsIconData.qr,
+          iconData: spec.glyph,
           color: Colors.white,
           size: width * 0.55,
         ),
       ),
     );
   }
+
+  /// Each slot is a soft-rectangle with the type's brand gradient and glyph, so
+  /// the family stays crisp at any size (no raster assets).
+  _SlotSpec _specFor(DotsIconItemSlotType type) {
+    switch (type) {
+      case DotsIconItemSlotType.cover:
+        return const _SlotSpec([Color(0xFFFAA25E), Color(0xFFF37C20)], DotsIconData.book2);
+      case DotsIconItemSlotType.dedicatory:
+        return const _SlotSpec([Color(0xFFFF5B69), Color(0xFFFF3F51)], DotsIconData.heart);
+      case DotsIconItemSlotType.images:
+        return const _SlotSpec([Color(0xFF61ED82), Color(0xFF32B74B)], DotsIconData.photoFrame);
+      case DotsIconItemSlotType.milestone:
+        return const _SlotSpec([Color(0xFFFFCD66), Color(0xFFFF9E11)], DotsIconData.star);
+      case DotsIconItemSlotType.qr:
+        return const _SlotSpec([Color(0xFF82C8E5), Color(0xFF4FAEF8)], DotsIconData.qr);
+    }
+  }
+}
+
+class _SlotSpec {
+  final List<Color> colors;
+  final DotsIconData glyph;
+
+  const _SlotSpec(this.colors, this.glyph);
 }
 
 enum DotsIconItemSlotType {


### PR DESCRIPTION
## What
Renders every `DotsIconItemSlot` as a **soft-rectangle** (rounded-square gradient + white glyph) instead of the per-type raster circle webps.

Per-type spec (from the Dotbook draft Figma):
- `images` → green `#61ED82→#32B74B`, photo glyph
- `qr` → blue `#82C8E5→#4FAEF8`, qr glyph
- `dedicatory` → red `#FF5B69→#FF3F51`, heart glyph
- `cover` → orange `#FAA25E→#F37C20`, book glyph
- `milestone` → gold `#FFCD66→#FF9E11`, star glyph

## Why
The updated Dotbook draft page (onelife_app #11174) uses soft-rectangle row icons, not circles. Composing them in code keeps them crisp at any size and self-contained (no new assets).

## Notes
- `DotsIconItem` is only consumed by the app's Dotbook draft manager, so this is visually contained.
- `flutter analyze` clean on the icons component; no existing `DotsIconItem` tests/goldens.
- Consumed by onelife_app branch `feature-11174-gestionar-codigos-qr-en-dotbook-de-recuerdos` (via a local `dependency_overrides` path until merged + tagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)