### PR TITLE
Document PageControl bounded-width contract

### DIFF
--- a/lib/src/components/dot_book/page_control.dart
+++ b/lib/src/components/dot_book/page_control.dart
@@ -9,6 +9,13 @@ enum PageControlVariant {
   bool get isBackground => this == PageControlVariant.background;
 }
 
+/// Page indicator dots, centered across the full width of its parent.
+///
+/// Internally lays out as `SizedBox(width: double.infinity)`, so it REQUIRES
+/// a bounded width. In unbounded contexts (`Positioned` without right/width,
+/// `Row` without Expanded, scrollables' cross axis) wrap it in a `SizedBox`;
+/// its natural width is `count × (dotSize + dotSpacing) + horizontal
+/// contentPadding` (main variant: `count × 16 + 24`).
 class PageControl extends StatelessWidget {
   /// Total number of dots to render.
   final int count;

--- a/lib/src/components/dot_book/page_control.dart
+++ b/lib/src/components/dot_book/page_control.dart
@@ -14,8 +14,8 @@ enum PageControlVariant {
 /// Internally lays out as `SizedBox(width: double.infinity)`, so it REQUIRES
 /// a bounded width. In unbounded contexts (`Positioned` without right/width,
 /// `Row` without Expanded, scrollables' cross axis) wrap it in a `SizedBox`;
-/// its natural width is `count × (dotSize + dotSpacing) + horizontal
-/// contentPadding` (main variant: `count × 16 + 24`).
+/// its natural width is `count × (dotSize + dotSpacing)` plus the horizontal
+/// `contentPadding` (main variant: `count × 16 + 24`).
 class PageControl extends StatelessWidget {
   /// Total number of dots to render.
   final int count;

--- a/tool/design_sync/components/dotbook/PageControl/PageControl.prompt.md
+++ b/tool/design_sync/components/dotbook/PageControl/PageControl.prompt.md
@@ -13,6 +13,8 @@ PageControl from dots_design_system. Use via `window.DotsDesignSystem_9e41da.Pag
 
 Ocupa el 100% del ancho con los puntos centrados (Row centrado en Flutter). Medidas por variante: main dot 8 / spacing 8 / padding 18px 12px; background dot 6 / spacing 12 / sin padding.
 
+⚠️ **Requiere ancho acotado en Flutter**: el widget Dart usa `SizedBox(width: double.infinity)` interno, así que en contextos sin límite de ancho (`Positioned` sin right/width, etc.) hay que envolverlo en un `SizedBox`. Su ancho natural es `count × (dot + spacing) + padding horizontal` — variante main: `count × 16 + 24` (p.ej. 72px con 3 puntos). En un diseño `.dc.html`, da ese valor en el `hint-size` para que la traducción a Flutter lo aplique.
+
 ## Examples
 
 ```jsx


### PR DESCRIPTION
## Qué

Documenta el contrato de ancho de `PageControl` en el Dart (doc-comment de clase) y en el `prompt.md` de su port en `tool/design_sync` — sin cambios de comportamiento.

## Por qué

`PageControl` usa `SizedBox(width: double.infinity)` + Row centrado: en contextos sin ancho acotado (`Positioned` sin right/width) lanza `BoxConstraints forces an infinite width`. Salió en su **primer uso fuera del dotbook** (GamesIntroPage, onelife_app#11411): el crash costó dos iteraciones (infinity → overflow de 12px por no contar el `contentPadding`).

La doc incluye la fórmula del ancho natural (`count × (dot + spacing) + padding h`; main: `count × 16 + 24`) para que los mockups de Claude Design lleven el `hint-size` correcto y la traducción a Flutter envuelva el componente automáticamente.

## Relacionado

Queda abierto como issue aparte el cambio de raíz (soportar contextos no acotados con un parámetro opcional, sin romper el dotbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)