### PR TITLE
feat(upload-item): let processText wrap instead of truncating

### DIFF
--- a/lib/src/components/upload_items/dots_upload_item.dart
+++ b/lib/src/components/upload_items/dots_upload_item.dart
@@ -28,6 +28,10 @@ class DotsUploadItem extends StatelessWidget {
   /// Elapsed time text to display when the upload is successful.
   final String? timeElapsed;
 
+  /// Maximum lines for [processText]. Null lets a long message wrap instead of
+  /// being cut with an ellipsis — used when the message carries a file name.
+  final int? processTextMaxLines;
+
   /// Text for the button displayed on the right side.
   final String? btnText;
 
@@ -42,6 +46,7 @@ class DotsUploadItem extends StatelessWidget {
     this.onError,
     this.textDate,
     this.processText,
+    this.processTextMaxLines = 1,
     this.timeElapsed,
     this.percentage,
     this.btnText,
@@ -98,13 +103,22 @@ class DotsUploadItem extends StatelessWidget {
                   ),
                   SizedBox(height: 6),
                   Row(
+                    crossAxisAlignment: processTextMaxLines == 1
+                        ? CrossAxisAlignment.center
+                        : CrossAxisAlignment.start,
                     children: [
-                      _RotatingIcon(
-                        animate: variant.isProcessing,
-                        child: DotsIcon(
-                          iconData: iconData,
-                          size: 14,
-                          color: iconColor,
+                      Padding(
+                        // Keeps the icon on the first line once the text wraps.
+                        padding: EdgeInsets.only(
+                          top: processTextMaxLines == 1 ? 0 : 2,
+                        ),
+                        child: _RotatingIcon(
+                          animate: variant.isProcessing,
+                          child: DotsIcon(
+                            iconData: iconData,
+                            size: 14,
+                            color: iconColor,
+                          ),
                         ),
                       ),
                       SizedBox(width: 3),
@@ -114,8 +128,10 @@ class DotsUploadItem extends StatelessWidget {
                           style: theme.typo.main.labelDefaultRegular.copyWith(
                             color: theme.colors.textSecondary,
                           ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                          maxLines: processTextMaxLines,
+                          overflow: processTextMaxLines == null
+                              ? TextOverflow.clip
+                              : TextOverflow.ellipsis,
                         ),
                       ),
                     ],

--- a/lib/src/components/upload_items/dots_upload_item.dart
+++ b/lib/src/components/upload_items/dots_upload_item.dart
@@ -51,7 +51,10 @@ class DotsUploadItem extends StatelessWidget {
     this.percentage,
     this.btnText,
     this.btnOnTap,
-  });
+  }) : assert(
+         processTextMaxLines == null || processTextMaxLines > 0,
+         'processTextMaxLines must be null (wrap freely) or greater than zero',
+       );
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/components/upload_items/dots_upload_item.dart
+++ b/lib/src/components/upload_items/dots_upload_item.dart
@@ -111,7 +111,8 @@ class DotsUploadItem extends StatelessWidget {
                         : CrossAxisAlignment.start,
                     children: [
                       Padding(
-                        // Keeps the icon on the first line once the text wraps.
+                        // Text allowed past one line grows downward, so top-align
+                        // and nudge the icon onto the first line.
                         padding: EdgeInsets.only(
                           top: processTextMaxLines == 1 ? 0 : 2,
                         ),

--- a/test/components/upload_items/dots_upload_item_test.dart
+++ b/test/components/upload_items/dots_upload_item_test.dart
@@ -7,71 +7,11 @@ import 'package:flutter_test/flutter_test.dart';
 
 /// 1x1 transparent PNG so the thumbnail resolves without hitting the network.
 final Uint8List _transparentPng = Uint8List.fromList(const [
-  0x89,
-  0x50,
-  0x4E,
-  0x47,
-  0x0D,
-  0x0A,
-  0x1A,
-  0x0A,
-  0x00,
-  0x00,
-  0x00,
-  0x0D,
-  0x49,
-  0x48,
-  0x44,
-  0x52, //
-  0x00,
-  0x00,
-  0x00,
-  0x01,
-  0x00,
-  0x00,
-  0x00,
-  0x01,
-  0x08,
-  0x06,
-  0x00,
-  0x00,
-  0x00,
-  0x1F,
-  0x15,
-  0xC4, //
-  0x89,
-  0x00,
-  0x00,
-  0x00,
-  0x0A,
-  0x49,
-  0x44,
-  0x41,
-  0x54,
-  0x78,
-  0x9C,
-  0x63,
-  0x00,
-  0x01,
-  0x00,
-  0x00, //
-  0x05,
-  0x00,
-  0x01,
-  0x0D,
-  0x0A,
-  0x2D,
-  0xB4,
-  0x00,
-  0x00,
-  0x00,
-  0x00,
-  0x49,
-  0x45,
-  0x4E,
-  0x44,
-  0xAE, //
-  0x42, 0x60, 0x82,
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, //
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, //
+  0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00, //
+  0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, //
+  0x42, 0x60, 0x82, //
 ]);
 
 const String _longProcessText =
@@ -81,14 +21,21 @@ const String _longProcessText =
 Widget _host(Widget child) => MaterialApp(
   theme: dotsThemeDataLight,
   home: Scaffold(
-    body: Center(
-      child: SizedBox(width: 360, child: child),
-    ),
+    body: Center(child: SizedBox(width: 360, child: child)),
   ),
 );
 
-Text _processTextWidget(WidgetTester tester) =>
-    tester.widget<Text>(find.text(_longProcessText));
+/// The error variant also paints a cloudFail glyph over the thumbnail, so the
+/// status icon has to be matched by its own glyph and size, not by position.
+final Finder _statusIcon = find.byWidgetPredicate(
+  (widget) =>
+      widget is DotsIcon && widget.iconData == DotsIconData.crossCircle && widget.size == 14,
+);
+
+Text _processText(WidgetTester tester) => tester.widget<Text>(find.text(_longProcessText));
+
+RenderParagraph _paragraph(WidgetTester tester) =>
+    tester.renderObject<RenderParagraph>(find.text(_longProcessText));
 
 void main() {
   Widget uploadItem({int? processTextMaxLines = 1}) => DotsUploadItem(
@@ -105,24 +52,21 @@ void main() {
     await tester.pumpWidget(_host(uploadItem()));
     await tester.pump();
 
-    final Text text = _processTextWidget(tester);
+    final Text text = _processText(tester);
     expect(text.maxLines, 1);
     expect(text.overflow, TextOverflow.ellipsis);
+    expect(_paragraph(tester).didExceedMaxLines, isTrue);
   });
 
-  testWidgets('renders the whole process text across lines when unbounded', (
-    tester,
-  ) async {
+  testWidgets('renders the whole process text across lines when unbounded', (tester) async {
     await tester.pumpWidget(_host(uploadItem(processTextMaxLines: null)));
     await tester.pump();
 
-    final Text text = _processTextWidget(tester);
+    final Text text = _processText(tester);
     expect(text.maxLines, isNull);
     expect(text.overflow, isNot(TextOverflow.ellipsis));
 
-    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
-      find.text(_longProcessText),
-    );
+    final RenderParagraph paragraph = _paragraph(tester);
     expect(paragraph.didExceedMaxLines, isFalse);
     expect(
       paragraph.size.height,
@@ -131,15 +75,19 @@ void main() {
     );
   });
 
-  testWidgets('keeps the status icon on the first line when the text wraps', (
-    tester,
-  ) async {
+  testWidgets('keeps the status icon on the first line when the text wraps', (tester) async {
     await tester.pumpWidget(_host(uploadItem(processTextMaxLines: null)));
     await tester.pump();
 
-    final double iconCenter = tester.getCenter(find.byType(DotsIcon).first).dy;
+    expect(_statusIcon, findsOneWidget);
+
+    final double iconCenter = tester.getCenter(_statusIcon).dy;
     final Rect textRect = tester.getRect(find.text(_longProcessText));
 
     expect(iconCenter, lessThan(textRect.center.dy));
+  });
+
+  testWidgets('rejects a non-positive max lines', (tester) async {
+    expect(() => uploadItem(processTextMaxLines: 0), throwsAssertionError);
   });
 }

--- a/test/components/upload_items/dots_upload_item_test.dart
+++ b/test/components/upload_items/dots_upload_item_test.dart
@@ -1,0 +1,145 @@
+import 'dart:typed_data';
+
+import 'package:dots_design_system/dots_design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// 1x1 transparent PNG so the thumbnail resolves without hitting the network.
+final Uint8List _transparentPng = Uint8List.fromList(const [
+  0x89,
+  0x50,
+  0x4E,
+  0x47,
+  0x0D,
+  0x0A,
+  0x1A,
+  0x0A,
+  0x00,
+  0x00,
+  0x00,
+  0x0D,
+  0x49,
+  0x48,
+  0x44,
+  0x52, //
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x08,
+  0x06,
+  0x00,
+  0x00,
+  0x00,
+  0x1F,
+  0x15,
+  0xC4, //
+  0x89,
+  0x00,
+  0x00,
+  0x00,
+  0x0A,
+  0x49,
+  0x44,
+  0x41,
+  0x54,
+  0x78,
+  0x9C,
+  0x63,
+  0x00,
+  0x01,
+  0x00,
+  0x00, //
+  0x05,
+  0x00,
+  0x01,
+  0x0D,
+  0x0A,
+  0x2D,
+  0xB4,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x49,
+  0x45,
+  0x4E,
+  0x44,
+  0xAE, //
+  0x42, 0x60, 0x82,
+]);
+
+const String _longProcessText =
+    'No encontramos el archivo IMG_20260824_183045_vacaciones_en_la_playa.HEIC '
+    'en este dispositivo. Vuelve a seleccionarlo para continuar la subida.';
+
+Widget _host(Widget child) => MaterialApp(
+  theme: dotsThemeDataLight,
+  home: Scaffold(
+    body: Center(
+      child: SizedBox(width: 360, child: child),
+    ),
+  ),
+);
+
+Text _processTextWidget(WidgetTester tester) =>
+    tester.widget<Text>(find.text(_longProcessText));
+
+void main() {
+  Widget uploadItem({int? processTextMaxLines = 1}) => DotsUploadItem(
+    image: MemoryImage(_transparentPng),
+    variant: UploadItemVariant.error,
+    textDate: '24 ago 2026',
+    processText: _longProcessText,
+    processTextMaxLines: processTextMaxLines,
+    btnText: 'Reintentar',
+    btnOnTap: () {},
+  );
+
+  testWidgets('clips the process text to one line by default', (tester) async {
+    await tester.pumpWidget(_host(uploadItem()));
+    await tester.pump();
+
+    final Text text = _processTextWidget(tester);
+    expect(text.maxLines, 1);
+    expect(text.overflow, TextOverflow.ellipsis);
+  });
+
+  testWidgets('renders the whole process text across lines when unbounded', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(uploadItem(processTextMaxLines: null)));
+    await tester.pump();
+
+    final Text text = _processTextWidget(tester);
+    expect(text.maxLines, isNull);
+    expect(text.overflow, isNot(TextOverflow.ellipsis));
+
+    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+      find.text(_longProcessText),
+    );
+    expect(paragraph.didExceedMaxLines, isFalse);
+    expect(
+      paragraph.size.height,
+      greaterThan(paragraph.getMinIntrinsicHeight(double.infinity)),
+      reason: 'the message should occupy more than a single line',
+    );
+  });
+
+  testWidgets('keeps the status icon on the first line when the text wraps', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(uploadItem(processTextMaxLines: null)));
+    await tester.pump();
+
+    final double iconCenter = tester.getCenter(find.byType(DotsIcon).first).dy;
+    final Rect textRect = tester.getRect(find.text(_longProcessText));
+
+    expect(iconCenter, lessThan(textRect.center.dy));
+  });
+}


### PR DESCRIPTION
## Problem

`DotsUploadItem` hardcoded `maxLines: 1` + `TextOverflow.ellipsis` on `processText`. When the message carries a file name — e.g. the web upload "we couldn't find *<file>*, re-select it" state — the ellipsis eats the file name, which is the one piece of information the message exists to deliver. Consumers pass only a `String`, so no app-side change could fix it.

## Change

- New `processTextMaxLines`, **defaulting to `1`** — every existing caller keeps today's rendering exactly.
- `null` lets the message wrap freely (`TextOverflow.clip`).
- When wrapping, the icon/text `Row` switches to `CrossAxisAlignment.start` with a 2px top pad, so the status icon stays level with the first line instead of drifting to the vertical centre of a multi-line block. Single-line behaviour is untouched.

## Tests

New `test/components/upload_items/dots_upload_item_test.dart`:

1. default still clips to one line with an ellipsis
2. unbounded renders taller than a single line, with `didExceedMaxLines == false` (nothing lost)
3. the status icon stays above the text's vertical centre when wrapped

Full suite green (6 tests), analyzer clean on the touched files.

## Notes

The diff is hand-wrapped rather than `dart format`-ed: running the formatter on this file rewrites 26 unrelated pre-existing lines, which would bury the change.

## Consumer

`onelife_app` — `group_landing_memory_progress.dart` opts in with `processTextMaxLines: isFileMissing ? null : 1`. That is the only `DotsUploadItem` call site in the app.