### PR TITLE
ci: tag y GitHub Release automáticos al mergear en develop

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Qué cambia
+
+<!-- Descripción breve. Si cierra una tarea, enlázala. -->
+
+## Release
+
+Al mergear se crea el tag y la GitHub Release automáticamente según la label de la PR. Pon **una**:
+
+- [ ] `release:patch` — fix sin cambio de API
+- [ ] `release:minor` — componente/prop nuevo, compatible hacia atrás
+- [ ] `release:major` — rompe API (renombrados, props eliminadas, cambios de comportamiento)
+- [ ] `release:skip` — docs, CI, tooling; no necesita tag
+
+<!-- Sin label el check "Release label" falla y no se puede mergear. -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,13 @@
+# Categorías de las release notes autogeneradas (gh release create --generate-notes)
+changelog:
+  exclude:
+    labels: ["release:skip"]
+  categories:
+    - title: "💥 Breaking changes"
+      labels: ["release:major"]
+    - title: "✨ Features"
+      labels: ["release:minor"]
+    - title: "🐛 Fixes"
+      labels: ["release:patch"]
+    - title: "Otros"
+      labels: ["*"]

--- a/.github/workflows/release-label.yml
+++ b/.github/workflows/release-label.yml
@@ -1,0 +1,29 @@
+# Check que obliga a que toda PR contra develop lleve exactamente una label release:*
+name: Release label
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+    branches: [develop]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  require-release-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check release:* label
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          count=$(tr ',' '\n' <<< "$LABELS" | grep -cE '^release:(major|minor|patch|skip)$' || true)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::Falta la label de release. Añade una de: release:major, release:minor, release:patch, release:skip"
+            exit 1
+          fi
+          if [ "$count" -gt 1 ]; then
+            echo "::error::Hay más de una label release:*. Deja solo una."
+            exit 1
+          fi
+          echo "OK: $(tr ',' '\n' <<< "$LABELS" | grep -E '^release:')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+# Crea tag + GitHub Release automáticamente al mergear una PR en develop.
+# El tipo de bump lo decide la label de la PR: release:major | release:minor | release:patch | release:skip
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve bump from PR label
+        id: bump
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          case ",$LABELS," in
+            *,release:major,*) bump=major ;;
+            *,release:minor,*) bump=minor ;;
+            *,release:patch,*) bump=patch ;;
+            *,release:skip,*)  bump=skip ;;
+            *) echo "::error::La PR no tiene label release:* (major|minor|patch|skip). No se crea release."; exit 1 ;;
+          esac
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+          echo "Bump: $bump"
+
+      - uses: actions/checkout@v4
+        if: steps.bump.outputs.bump != 'skip'
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Compute next version
+        if: steps.bump.outputs.bump != 'skip'
+        id: ver
+        env:
+          BUMP: ${{ steps.bump.outputs.bump }}
+        run: |
+          # Solo tags estrictamente vX.Y.Z (ignora cosas como "v.1.53.16")
+          last=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          last=${last:-v0.0.0}
+          IFS=. read -r M m p <<< "${last#v}"
+          case "$BUMP" in
+            major) M=$((M+1)); m=0; p=0 ;;
+            minor) m=$((m+1)); p=0 ;;
+            patch) p=$((p+1)) ;;
+          esac
+          next="v$M.$m.$p"
+          if git rev-parse -q --verify "refs/tags/$next" >/dev/null; then
+            echo "::error::El tag $next ya existe"; exit 1
+          fi
+          echo "last=$last" >> "$GITHUB_OUTPUT"
+          echo "tag=$next"   >> "$GITHUB_OUTPUT"
+          echo "$last -> $next"
+
+      - name: Create tag
+        if: steps.bump.outputs.bump != 'skip'
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" "$SHA" -m "$TAG: $PR_TITLE (#$PR_NUMBER)"
+          git push origin "refs/tags/$TAG"
+
+      - name: Create GitHub Release
+        if: steps.bump.outputs.bump != 'skip'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          LAST: ${{ steps.ver.outputs.last }}
+        run: |
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" \
+            --generate-notes \
+            --notes-start-tag "$LAST"
+          echo "## Release $TAG creada ($LAST → $TAG)" >> "$GITHUB_STEP_SUMMARY"
+          echo "https://github.com/$GITHUB_REPOSITORY/releases/tag/$TAG" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Skipped
+        if: steps.bump.outputs.bump == 'skip'
+        run: echo "## release:skip — no se crea tag ni release" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Automatiza lo que hoy hacemos a mano tras cada merge: crear el tag `vX.Y.Z` y la GitHub Release.

## Cómo funciona

1. Toda PR contra `develop` lleva **una** label `release:*`. El check **Release label** falla si falta o hay más de una.
2. Al mergear, el workflow **Release** lee la label, calcula la siguiente versión a partir del tag `vX.Y.Z` más alto (ignora malformados como `v.1.53.16`), crea un tag anotado sobre el merge commit y una GitHub Release con notas autogeneradas (agrupadas por `.github/release.yml`).

| Label | Efecto |
|---|---|
| `release:major` | `v1.71.5` → `v2.0.0` |
| `release:minor` | `v1.71.5` → `v1.72.0` |
| `release:patch` | `v1.71.5` → `v1.71.6` |
| `release:skip` | nada (docs, CI, tooling) |

## Qué no hace (a propósito)

- No toca `pubspec.yaml` ni `CHANGELOG.md`: hoy nadie los consume (`onelife_app` tira del `ref` de git). Se puede añadir después.
- No configura el check como *required* en la protección de `develop`: hay que hacerlo a mano en Settings → Branches una vez veamos que funciona.

## Prueba

Esta PR va con `release:skip` (el workflow corre y no hace nada). La primera release real será #446, que ya lleva `release:minor` → `v1.72.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)